### PR TITLE
Conformance to UISegmentedControl

### DIFF
--- a/SMSegmentViewController/SMSegmentView/SMBasicSegmentView.swift
+++ b/SMSegmentViewController/SMSegmentView/SMBasicSegmentView.swift
@@ -34,13 +34,22 @@ public class SMBasicSegmentView: UIControl {
         }
     }
     public weak var delegate: SMSegmentViewDelegate?
-    
 
     public var selectedSegmentIndex: Int = UISegmentedControlNoSegment{
         didSet{
             if selectedSegmentIndex != oldValue { self.selectSegmentAtIndex(selectedSegmentIndex) }
         }
     }
+    //Make it dissapear in one of the next versions
+    @available(*, deprecated=1.2.0)
+    public var indexOfSelectedSegment: Int {
+        get { return selectedSegmentIndex == UISegmentedControlNoSegment ? NSNotFound : selectedSegmentIndex }
+        set {
+            if indexOfSelectedSegment == NSNotFound { selectedSegmentIndex = UISegmentedControlNoSegment }
+            else { selectedSegmentIndex = indexOfSelectedSegment }
+        }
+    }
+    
     public var numberOfSegments: Int {get {
         return segments.count
         }}
@@ -151,7 +160,6 @@ public class SMBasicSegmentView: UIControl {
     
     // MARK: Actions
     public func selectSegmentAtIndex(index: Int) {
-        guard self.selectedSegmentIndex != index else {return}
         guard (index >= 0 && index < self.segments.count) || (index == UISegmentedControlNoSegment) else {
             NSLog("Index at \(index) is out of bounds")
             return

--- a/SMSegmentViewController/SMSegmentView/SMBasicSegmentView.swift
+++ b/SMSegmentViewController/SMSegmentView/SMBasicSegmentView.swift
@@ -19,7 +19,7 @@ public protocol SMSegmentViewDelegate: class {
     func segmentView(segmentView: SMBasicSegmentView, didSelectSegmentAtIndex index: Int)
 }
 
-public class SMBasicSegmentView: UIView {
+public class SMBasicSegmentView: UIControl {
     public var segments: [SMBasicSegment] = [] {
         didSet {
             var i=0;
@@ -35,8 +35,13 @@ public class SMBasicSegmentView: UIView {
     }
     public weak var delegate: SMSegmentViewDelegate?
     
-    public private(set) var indexOfSelectedSegment: Int = NSNotFound
-    var numberOfSegments: Int {get {
+
+    public var selectedSegmentIndex: Int = UISegmentedControlNoSegment{
+        didSet{
+            if selectedSegmentIndex != oldValue { self.selectSegmentAtIndex(selectedSegmentIndex) }
+        }
+    }
+    public var numberOfSegments: Int {get {
         return segments.count
         }}
     
@@ -146,23 +151,34 @@ public class SMBasicSegmentView: UIView {
     
     // MARK: Actions
     public func selectSegmentAtIndex(index: Int) {
-        assert(index >= 0 && index < self.segments.count, "Index at \(index) is out of bounds")
+        guard self.selectedSegmentIndex != index else {return}
+        guard (index >= 0 && index < self.segments.count) || (index == UISegmentedControlNoSegment) else {
+            NSLog("Index at \(index) is out of bounds")
+            return
+        }
+        defer {
+            self.sendActionsForControlEvents(.ValueChanged)
+        }
         
-        if self.indexOfSelectedSegment != NSNotFound {
-            let previousSelectedSegment = self.segments[self.indexOfSelectedSegment]
+        if self.selectedSegmentIndex != UISegmentedControlNoSegment {
+            let previousSelectedSegment = self.segments[self.selectedSegmentIndex]
             previousSelectedSegment.setSelected(false, inView: self)
         }
-        self.indexOfSelectedSegment = index
+        selectedSegmentIndex = index
+        if index == UISegmentedControlNoSegment {
+            return
+        }
+        
         let segment = self.segments[index]
         segment.setSelected(true, inView: self)
         self.delegate?.segmentView(self, didSelectSegmentAtIndex: index)
     }
     
     public func deselectSegment() {
-        if self.indexOfSelectedSegment != NSNotFound {
-            let segment = self.segments[self.indexOfSelectedSegment]
+        if self.selectedSegmentIndex != UISegmentedControlNoSegment {
+            let segment = self.segments[self.selectedSegmentIndex]
             segment.setSelected(false, inView: self)
-            self.indexOfSelectedSegment = NSNotFound
+            self.selectedSegmentIndex = NSNotFound
         }
     }
     

--- a/SMSegmentViewController/ViewController.swift
+++ b/SMSegmentViewController/ViewController.swift
@@ -42,6 +42,7 @@ class ViewController: UIViewController {
         
         // Set segment with index 0 as selected by default
         //segmentView.selectSegmentAtIndex(0)
+        segmentView.indexOfSelectedSegment = 0
         self.view.addSubview(view)
         
         

--- a/SMSegmentViewController/ViewController.swift
+++ b/SMSegmentViewController/ViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ViewController: UIViewController, SMSegmentViewDelegate {
+class ViewController: UIViewController {
     
     var segmentView: SMSegmentView!
     var alphaSegmentView: SMBasicSegmentView!
@@ -26,8 +26,8 @@ class ViewController: UIViewController, SMSegmentViewDelegate {
         
         self.segmentView = SMSegmentView(frame: segmentFrame, separatorColour: UIColor(white: 0.95, alpha: 0.3), separatorWidth: 0.5, segmentProperties: [keySegmentTitleFont: UIFont.systemFontOfSize(12.0), keySegmentOnSelectionColour: UIColor(red: 245.0/255.0, green: 174.0/255.0, blue: 63.0/255.0, alpha: 1.0), keySegmentOffSelectionColour: UIColor.whiteColor(), keyContentVerticalMargin: Float(10.0)])
         
-        self.segmentView.delegate = self
-        
+        //self.segmentView.delegate = self
+        self.segmentView.addTarget(self, action: "segmentView:", forControlEvents: .ValueChanged)
         self.segmentView.backgroundColor = UIColor.clearColor()
         
         self.segmentView.layer.cornerRadius = 5.0
@@ -64,12 +64,12 @@ class ViewController: UIViewController, SMSegmentViewDelegate {
         self.view.addSubview(self.alphaSegmentView)
     }
 
-    // SMSegment Delegate
-    func segmentView(segmentView: SMBasicSegmentView, didSelectSegmentAtIndex index: Int) {
+    // SMSegment selector
+    func segmentView(segmentView: SMBasicSegmentView) {
         /*
         Replace the following line to implement what you want the app to do after the segment gets tapped.
         */
-        print("Select segment at index: \(index)")
+        print("Select segment at index: \(segmentView.selectedSegmentIndex)")
     }
     
     override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {


### PR DESCRIPTION
Hi.
Changed base class of `SMBasicSegmentView` to `UIControl` and added action sending for `ValueChanged` - the same as in UISegmentedControl.
Also added `selectedSegmentIndex` property (same as in UISegmentedControl) while deprecating `indexOfSelectedSegment`. Both works properly so there are no breaking changes, but at some time you could delete the deprecated property.

I assumed the next version will be `1.2.0` so I used it in the `@available` annotation, but you could of course change it to your needs. If you would like to I can add another commit with changed `Info.plist` and `.podspec` for `1.2.0` version.
