### PR TITLE
Added objc attribute to Swift protocol

### DIFF
--- a/SMSegmentViewController/SMSegmentView/SMBasicSegmentView.swift
+++ b/SMSegmentViewController/SMSegmentView/SMBasicSegmentView.swift
@@ -15,7 +15,7 @@ public enum SegmentOrganiseMode: Int {
 }
 
 
-public protocol SMSegmentViewDelegate: class {
+@objc public protocol SMSegmentViewDelegate: class {
     func segmentView(segmentView: SMBasicSegmentView, didSelectSegmentAtIndex index: Int)
 }
 


### PR DESCRIPTION
This fixes 'does not conform to protocol' error.
