### PR TITLE
Add touchesCancelled handling

### DIFF
--- a/SMSegmentViewController/SMSegmentView/SMSegment.swift
+++ b/SMSegmentViewController/SMSegmentView/SMSegment.swift
@@ -133,4 +133,8 @@ open class SMSegment: UIView {
             self.didSelectSegment?(self)
         }
     }
+    
+    open override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        backgroundColor = isSelected ? self.appearance?.segmentOnSelectionColour : self.appearance?.segmentOffSelectionColour
+    }
 }


### PR DESCRIPTION
Allow `SMSegmentView` appearance to reset when a touch is cancelled. See issue #28.