### PR TITLE
Update SMSegment.swift

### DIFF
--- a/SMSegmentViewController/SMSegmentView/SMSegment.swift
+++ b/SMSegmentViewController/SMSegmentView/SMSegment.swift
@@ -109,6 +109,7 @@ open class SMSegment: UIView {
             DispatchQueue.main.async(execute: {
                 self.backgroundColor = self.appearance?.segmentOnSelectionColour
                 self.label.textColor = self.appearance?.titleOnSelectionColour
+                self.label.font = self.appearance?.titleOnSelectionFont
                 self.imageView.image = self.onSelectionImage
             })
         }
@@ -116,6 +117,7 @@ open class SMSegment: UIView {
             DispatchQueue.main.async(execute: {
                 self.backgroundColor = self.appearance?.segmentOffSelectionColour
                 self.label.textColor = self.appearance?.titleOffSelectionColour
+                self.label.font = self.appearance?.titleOffSelectionFont
                 self.imageView.image = self.offSelectionImage
             })
         }


### PR DESCRIPTION
At the moment 'titleOffSelectionFont' is ignored as it is never used inside of the code. The proposed change will update the font of the segment's label in the setSelected method to ensure that correct font is being used.