### PR TITLE
Add Auto Layout to SMSegment

### DIFF
--- a/SMSegmentViewController/SMSegmentView/SMSegment.swift
+++ b/SMSegmentViewController/SMSegmentView/SMSegment.swift
@@ -42,23 +42,71 @@ open class SMSegment: UIView {
         self.appearance = appearance
         
         super.init(frame: CGRect.zero)
-        self.addUIElementsToView()
     }
     
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    fileprivate func addUIElementsToView() {
-        
+    internal func setupUIElements() {
         self.imageView.contentMode = UIViewContentMode.scaleAspectFit
-        self.addSubview(self.imageView)
+        
         
         self.label.textAlignment = NSTextAlignment.center
-        self.addSubview(self.label)
-    }
-    
-    internal func setupUIElements() {
+        self.label.translatesAutoresizingMaskIntoConstraints = false
+        self.imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        var verticalMargin: CGFloat = 0.0
+        if let appearance = self.appearance {
+            verticalMargin = appearance.contentVerticalMargin
+        }
+        
+        let imagePresent = (self.offSelectionImage != nil) || (self.onSelectionImage != nil)
+        var titlePresent = false
+        if let title = self.title {
+            titlePresent = (title != "")
+        }
+        if imagePresent && titlePresent {
+            // we have both image and title so we need to center them together
+            let view = UIView(frame: CGRect.zero) // this will be used to hold the image and label inside
+            
+            view.translatesAutoresizingMaskIntoConstraints = false
+            
+            view.addSubview(self.imageView)
+            view.addSubview(self.label)
+            
+            view.leadingAnchor.constraint(equalTo: self.imageView.leadingAnchor).isActive = true
+            view.trailingAnchor.constraint(equalTo: self.label.trailingAnchor).isActive = true
+            self.label.leadingAnchor.constraint(equalTo: self.imageView.trailingAnchor, constant: 5.0).isActive = true // this is used to separate image and label
+            
+            view.topAnchor.constraint(lessThanOrEqualTo: self.imageView.topAnchor).isActive = true
+            view.topAnchor.constraint(lessThanOrEqualTo: self.label.topAnchor).isActive = true
+            
+            view.centerYAnchor.constraint(equalTo: self.imageView.centerYAnchor).isActive = true
+            view.centerYAnchor.constraint(equalTo: self.label.centerYAnchor).isActive = true
+            
+            self.addSubview(view)
+            
+            self.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+            self.topAnchor.constraint(equalTo: view.topAnchor, constant:-verticalMargin).isActive = true
+            self.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        }
+        else if imagePresent {
+            self.addSubview(self.imageView)
+            self.centerXAnchor.constraint(equalTo: self.imageView.centerXAnchor).isActive = true
+            self.centerYAnchor.constraint(equalTo: self.imageView.centerYAnchor).isActive = true
+            self.topAnchor.constraint(lessThanOrEqualTo: self.imageView.topAnchor, constant: -verticalMargin).isActive = true
+        }
+        else if titlePresent {
+            self.addSubview(self.label)
+            self.centerXAnchor.constraint(equalTo: self.label.centerXAnchor).isActive = true
+            self.centerYAnchor.constraint(equalTo: self.label.centerYAnchor).isActive = true
+            self.topAnchor.constraint(lessThanOrEqualTo: self.label.topAnchor, constant: -verticalMargin).isActive = true
+        }
+        
+        
+        
+        
         DispatchQueue.main.async(execute: {
             if let appearance = self.appearance {
                 self.backgroundColor = appearance.segmentOffSelectionColour
@@ -69,39 +117,6 @@ open class SMSegment: UIView {
         })
     }
     
-    
-    // MARK: Update label and imageView frame
-    open override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        var distanceBetween: CGFloat = 0.0
-        
-        var verticalMargin: CGFloat = 0.0
-        if let appearance = self.appearance {
-            verticalMargin = appearance.contentVerticalMargin
-        }
-        
-        var imageViewFrame = CGRect(x: 0.0, y: verticalMargin, width: 0.0, height: self.frame.size.height - verticalMargin*2)
-        if self.onSelectionImage != nil || self.offSelectionImage != nil {
-            // Set imageView as a square
-            imageViewFrame.size.width = self.frame.size.height - verticalMargin*2
-            distanceBetween = 5.0
-        }
-        
-        // If there's no text, align image in the centre
-        // Otherwise align text & image in the centre
-        self.label.sizeToFit()
-        if self.label.frame.size.width == 0.0 {
-            imageViewFrame.origin.x = max((self.frame.size.width - imageViewFrame.size.width) / 2.0, 0.0)
-        }
-        else {
-            imageViewFrame.origin.x = max((self.frame.size.width - imageViewFrame.size.width - self.label.frame.size.width) / 2.0 - distanceBetween, 0.0)
-        }
-        
-        self.imageView.frame = imageViewFrame
-        self.label.frame = CGRect(x: imageViewFrame.origin.x + imageViewFrame.size.width + distanceBetween, y: verticalMargin, width: self.label.frame.size.width, height: self.frame.size.height - verticalMargin * 2)
-    }
-    
     // MARK: Selections
     internal func setSelected(_ selected: Bool) {
         self.isSelected = selected
@@ -109,6 +124,7 @@ open class SMSegment: UIView {
             DispatchQueue.main.async(execute: {
                 self.backgroundColor = self.appearance?.segmentOnSelectionColour
                 self.label.textColor = self.appearance?.titleOnSelectionColour
+                self.label.font = self.appearance?.titleOnSelectionFont
                 self.imageView.image = self.onSelectionImage
             })
         }
@@ -116,6 +132,7 @@ open class SMSegment: UIView {
             DispatchQueue.main.async(execute: {
                 self.backgroundColor = self.appearance?.segmentOffSelectionColour
                 self.label.textColor = self.appearance?.titleOffSelectionColour
+                self.label.font = self.appearance?.titleOffSelectionFont
                 self.imageView.image = self.offSelectionImage
             })
         }


### PR DESCRIPTION
At the moment SMSegment does not support custom onSelectionFontColor even though it is declared.

This commit adds support for it. However, in order to make it work, several changes needed to be made to support auto layout instead of manual label/image sizing. In the later case the following case was problematic:

1) Segment is loaded with some default title and regular font
2) It is selected and the font is changed to bold

The result was often that the frame size would not update properly and hence the label was kept the same size as before. However, as the same text cannot fit in such a space with bold font only "..." would appear.

Adding auto layout resolves this issue.

Some things I would like to point:

1) This commit does not handle the case if the label is too wide. Although it is very easy to add this support by specifying few extra constraints
2) I have tested it on segments with titles only and it works really well.