### PR TITLE
Fix layoutSubviews invocations. Remove setter main thread trampolining. 

### DIFF
--- a/SMSegmentViewController/SMSegmentView/SMSegment.swift
+++ b/SMSegmentViewController/SMSegmentView/SMSegment.swift
@@ -16,10 +16,8 @@ open class SMSegment: UIView {
     // Title
     public var title: String? {
         didSet {
-            DispatchQueue.main.async(execute: {
-                self.label.text = self.title
-                self.layoutSubviews()
-            })
+            self.label.text = title
+            setNeedsLayout()
         }
     }
     

--- a/SMSegmentViewController/SMSegmentView/SMSegment.swift
+++ b/SMSegmentViewController/SMSegmentView/SMSegment.swift
@@ -17,7 +17,7 @@ open class SMSegment: UIView {
     public var title: String? {
         didSet {
             self.label.text = title
-            setNeedsLayout()
+            self.setNeedsLayout()
         }
     }
     
@@ -61,14 +61,12 @@ open class SMSegment: UIView {
     }
     
     internal func setupUIElements() {
-        DispatchQueue.main.async(execute: {
-            if let appearance = self.appearance {
-                self.backgroundColor = appearance.segmentOffSelectionColour
-                self.label.font = appearance.titleOffSelectionFont
-                self.label.textColor = appearance.titleOffSelectionColour
-            }
-            self.imageView.image = self.offSelectionImage
-        })
+        if let appearance = self.appearance {
+            self.backgroundColor = appearance.segmentOffSelectionColour
+            self.label.font = appearance.titleOffSelectionFont
+            self.label.textColor = appearance.titleOffSelectionColour
+        }
+        self.imageView.image = self.offSelectionImage
     }
     
     
@@ -182,18 +180,14 @@ open class SMSegment: UIView {
     internal func setSelected(_ selected: Bool) {
         self.isSelected = selected
         if selected == true {
-            DispatchQueue.main.async(execute: {
-                self.backgroundColor = self.appearance?.segmentOnSelectionColour
-                self.label.textColor = self.appearance?.titleOnSelectionColour
-                self.imageView.image = self.onSelectionImage
-            })
+            self.backgroundColor = self.appearance?.segmentOnSelectionColour
+            self.label.textColor = self.appearance?.titleOnSelectionColour
+            self.imageView.image = self.onSelectionImage
         }
         else {
-            DispatchQueue.main.async(execute: {
-                self.backgroundColor = self.appearance?.segmentOffSelectionColour
-                self.label.textColor = self.appearance?.titleOffSelectionColour
-                self.imageView.image = self.offSelectionImage
-            })
+            self.backgroundColor = self.appearance?.segmentOffSelectionColour
+            self.label.textColor = self.appearance?.titleOffSelectionColour
+            self.imageView.image = self.offSelectionImage
         }
     }
     

--- a/SMSegmentViewController/SMSegmentView/SMSegmentView.swift
+++ b/SMSegmentViewController/SMSegmentView/SMSegmentView.swift
@@ -124,7 +124,6 @@ open class SMSegmentView: UIControl {
         self.segments.insert(segment, at: index)
 
         self.addSubview(segment)
-        self.layoutSubviews()
     }
     
     // MARK: Remove Segment


### PR DESCRIPTION
`-layoutSubviews` should never be executed manually. Always invoke `-setNeedsLayout` (and `-layoutIfNeeded` if absolutely needed).

Also, it's a generally known convention that setters on UI components should be executed on the main thread. There's no need to trampoline to the main thread again. 